### PR TITLE
Adjust padding and add spacer in SettingsScreen

### DIFF
--- a/app/src/main/java/com/cbouvat/android/saracroche/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/cbouvat/android/saracroche/ui/settings/SettingsScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -296,7 +297,7 @@ fun SettingsScreen() {
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(64.dp),
+                    .padding(32.dp),
                 contentAlignment = Alignment.Center
             ) {
                 Column(
@@ -314,6 +315,9 @@ fun SettingsScreen() {
                     )
                 }
             }
+
+            // Space to ensure content is not cut off
+            Spacer(modifier = Modifier.height(64.dp))
         }
     }
 }


### PR DESCRIPTION
This pull request makes adjustments to the `SettingsScreen` in the `app/src/main/java/com/cbouvat/android/saracroche/ui/settings/SettingsScreen.kt` file to improve layout spacing and ensure proper content display. The key changes include reducing padding, adding a spacer for better layout handling, and importing the necessary layout component.

### Layout adjustments:

* Reduced padding in the `Box` modifier from `64.dp` to `32.dp` to provide a more compact layout.
* Added a `Spacer` with a height of `64.dp` at the bottom of the `SettingsScreen` to prevent content from being cut off.

### Code additions:

* Imported `height` from `androidx.compose.foundation.layout` to support the new `Spacer` component.