### PR TITLE
Update help content for clarity and punctuation

### DIFF
--- a/app/src/main/java/com/cbouvat/android/saracroche/ui/help/HelpScreen.kt
+++ b/app/src/main/java/com/cbouvat/android/saracroche/ui/help/HelpScreen.kt
@@ -197,7 +197,7 @@ fun HelpScreen() {
             }
         ),
         HelpItem(
-            title = "Respect de la vie privée",
+            title = "Respect de la vie privée ?",
             icon = Icons.Rounded.Lock,
             content = "Saracroche ne collecte aucune donnée personnelle, n'utilise aucun service tiers et ne transmet aucune information à qui que ce soit. Toutes les données restent sur votre appareil. Le respect de la vie privée est un droit fondamental, même si on n'a rien à cacher."
         ),
@@ -214,7 +214,7 @@ fun HelpScreen() {
         HelpItem(
             title = "Pourquoi une patte d'ours ?",
             icon = Icons.Rounded.Bolt,
-            content = "Sarah est une ourse qui a été sauvée par Camille, le développeur de l'application. C'est elle qui raccroche en disant : « Tu connais Sarah ? », l'autre répond : « Sarah qui ? », et elle répond : « Sarah Croche ! » à chaque appel indésirable qu'elle reçoit. Merci à Sarah",
+            content = "Sarah est une ourse qui a été sauvée par Camille, le développeur de l'application. C'est elle qui raccroche en disant : « Tu connais Sarah ? », l'autre répond : « Sarah qui ? », et elle répond : « Sarah Croche ! » à chaque appel indésirable qu'elle reçoit. Merci à Sarah.",
         )
     )
 


### PR DESCRIPTION
This pull request makes minor textual adjustments in the `HelpScreen` of the application to improve clarity and consistency in the displayed content.

* Textual changes in `HelpScreen`:
  * Updated the title of the "Respect de la vie privée" section to include a question mark for better alignment with its content. (`app/src/main/java/com/cbouvat/android/saracroche/ui/help/HelpScreen.kt`, [app/src/main/java/com/cbouvat/android/saracroche/ui/help/HelpScreen.ktL200-R200](diffhunk://#diff-ebf5c462d9ddba0164c73786bd699fad2f08894a2d26d4de7c54425fbabbcf05L200-R200))
  * Added a period at the end of the "Pourquoi une patte d'ours ?" section content to ensure consistent punctuation. (`app/src/main/java/com/cbouvat/android/saracroche/ui/help/HelpScreen.kt`, [app/src/main/java/com/cbouvat/android/saracroche/ui/help/HelpScreen.ktL217-R217](diffhunk://#diff-ebf5c462d9ddba0164c73786bd699fad2f08894a2d26d4de7c54425fbabbcf05L217-R217))