### PR TITLE
Refactor DonationSheet buttons and fix HomeScreen text

### DIFF
--- a/app/src/main/java/com/cbouvat/android/saracroche/network/NetworkService.kt
+++ b/app/src/main/java/com/cbouvat/android/saracroche/network/NetworkService.kt
@@ -28,30 +28,30 @@ class NetworkService(private val context: Context) {
             val connection = url.openConnection() as HttpURLConnection
 
             try {
-                // Configuration de la connexion
+                // Connection configuration
                 connection.requestMethod = "POST"
                 connection.setRequestProperty("Content-Type", "application/json")
                 connection.doOutput = true
                 connection.connectTimeout = TIMEOUT_SECONDS * 1000
                 connection.readTimeout = RESOURCE_TIMEOUT_SECONDS * 1000
 
-                // Création de la requête
+                // Build request body
                 val requestData = ReportRequest(
                     number = phoneNumber,
                     deviceId = getDeviceId(),
                     appVersion = getAppVersion()
                 )
 
-                // Envoi des données
+                // Send JSON payload
                 val jsonData = gson.toJson(requestData)
                 connection.outputStream.use { outputStream ->
                     outputStream.write(jsonData.toByteArray(StandardCharsets.UTF_8))
                 }
 
-                // Vérification de la réponse
+                // Handle response status code
                 when (val responseCode = connection.responseCode) {
                     in 200..299 -> {
-                        // Succès, rien à faire
+                        // Success: nothing else to do
                         return@withContext
                     }
 
@@ -84,12 +84,12 @@ class NetworkService(private val context: Context) {
             if (errorStream != null) {
                 val errorText = errorStream.bufferedReader().use { it.readText() }
 
-                // Tentative de parsing JSON
+                // Try to parse JSON structured error
                 try {
                     val errorResponse = gson.fromJson(errorText, ErrorResponse::class.java)
                     errorResponse.message ?: errorResponse.error ?: errorResponse.detail
                 } catch (e: JsonSyntaxException) {
-                    // Si ce n'est pas du JSON, retourner le texte brut
+                    // Not JSON: return raw text if present
                     if (errorText.isNotBlank()) errorText else null
                 }
             } else {

--- a/app/src/main/java/com/cbouvat/android/saracroche/ui/donation/DonationSheet.kt
+++ b/app/src/main/java/com/cbouvat/android/saracroche/ui/donation/DonationSheet.kt
@@ -17,12 +17,14 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Code
+import androidx.compose.material.icons.rounded.CreditCard
 import androidx.compose.material.icons.rounded.Favorite
 import androidx.compose.material.icons.rounded.Lock
 import androidx.compose.material.icons.rounded.Person
 import androidx.compose.material.icons.rounded.Refresh
 import androidx.compose.material.icons.rounded.Savings
 import androidx.compose.material.icons.rounded.Star
+import androidx.compose.material.icons.rounded.Wallet
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -133,49 +135,86 @@ fun DonationSheet(
 
             Spacer(modifier = Modifier.height(24.dp))
 
-            // Donation buttons
-            DonationButton(
-                text = "Carte bancaire",
-                // Indigo color for Stripe
-                backgroundColor = Color(0xFF6772E5),
-                textColor = Color.White,
+            Button(
                 onClick = { openUrl(context, "https://buy.stripe.com/9B6aEXcJ8flofsgfIU2oE01") },
-                modifier = Modifier.fillMaxWidth()
-            )
-
-            Spacer(modifier = Modifier.height(12.dp))
-
-            DonationButton(
-                text = "PayPal",
-                backgroundColor = Color(0xFF0070BA),
-                textColor = Color.White,
-                onClick = { openUrl(context, "https://paypal.me/cbouvat") },
-                modifier = Modifier.fillMaxWidth()
-            )
-
-            Spacer(modifier = Modifier.height(12.dp))
-
-            Row(modifier = Modifier.fillMaxWidth()) {
-                DonationButton(
-                    text = "GitHub Sponsors",
-                    backgroundColor = Color.Black,
-                    textColor = Color.White,
-                    onClick = { openUrl(context, "https://github.com/sponsors/cbouvat") },
-                    modifier = Modifier.weight(1f)
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Color(0xFF6772E5), // Stripe indigo
+                    contentColor = Color.White
                 )
-                Spacer(modifier = Modifier.width(12.dp))
-                DonationButton(
-                    text = "Liberapay",
-                    backgroundColor = Color(0xFFF6C915),
-                    textColor = Color.Black,
-                    onClick = { openUrl(context, "https://liberapay.com/cbouvat") },
-                    modifier = Modifier.weight(1f)
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.CreditCard,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    "Carte bancaire & Google Pay",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.SemiBold
                 )
             }
 
             Spacer(modifier = Modifier.height(12.dp))
 
-            // App rating button
+            Button(
+                onClick = { openUrl(context, "https://paypal.me/cbouvat") },
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Color(0xFF0070BA), // PayPal blue
+                    contentColor = Color.White
+                )
+            ) {
+                Icon(
+                    imageVector = Icons.Rounded.Wallet,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    "PayPal",
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Row(modifier = Modifier.fillMaxWidth()) {
+                Button(
+                    onClick = { openUrl(context, "https://github.com/sponsors/cbouvat") },
+                    modifier = Modifier.weight(1f),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = Color.Black,
+                        contentColor = Color.White
+                    )
+                ) {
+                    Text(
+                        "GitHub",
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                }
+                Spacer(modifier = Modifier.width(12.dp))
+                Button(
+                    onClick = { openUrl(context, "https://liberapay.com/cbouvat") },
+                    modifier = Modifier.weight(1f),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = Color(0xFFF6C915), // Liberapay yellow
+                        contentColor = Color.Black
+                    )
+                ) {
+                    Text(
+                        "Liberapay",
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontWeight = FontWeight.SemiBold
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
             Button(
                 onClick = { openPlayStore(context) },
                 modifier = Modifier.fillMaxWidth(),
@@ -240,32 +279,6 @@ fun DonationBenefitRow(
     }
 }
 
-@Composable
-fun DonationButton(
-    text: String,
-    backgroundColor: Color,
-    textColor: Color,
-    modifier: Modifier,
-    onClick: () -> Unit
-) {
-    Button(
-        onClick = onClick,
-        modifier = modifier,
-        colors = ButtonDefaults.buttonColors(
-            containerColor = backgroundColor,
-            contentColor = textColor
-        )
-    ) {
-        Icon(
-            imageVector = Icons.Rounded.Favorite,
-            contentDescription = null,
-            modifier = Modifier.size(18.dp)
-        )
-        Spacer(modifier = Modifier.width(8.dp))
-        Text(text, style = MaterialTheme.typography.bodyMedium, fontWeight = FontWeight.SemiBold)
-    }
-}
-
 private fun openUrl(context: Context, url: String) {
     try {
         val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
@@ -277,12 +290,10 @@ private fun openUrl(context: Context, url: String) {
 
 private fun openPlayStore(context: Context) {
     try {
-        // Try to open the app page in Google Play Store app
         val playStoreIntent =
             Intent(Intent.ACTION_VIEW, Uri.parse("market://details?id=${context.packageName}"))
         context.startActivity(playStoreIntent)
     } catch (e: Exception) {
-        // If Play Store app is not available, open in browser
         try {
             val browserIntent = Intent(
                 Intent.ACTION_VIEW,

--- a/app/src/main/java/com/cbouvat/android/saracroche/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/cbouvat/android/saracroche/ui/home/HomeScreen.kt
@@ -248,7 +248,7 @@ fun BlockedPatternsStatsCard(
                 )
 
                 Text(
-                    text = "Les appels bloqués apparaîtront dans le journal d'appels avec un symbole indiquant qu'ils ont été bloqués. Vous recevrez aucune notification pour ces appels.",
+                    text = "Les appels bloqués apparaissent dans le journal d’appels avec un symbole indiquant leur blocage. Aucune notification n’est envoyée pour ces appels.",
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     textAlign = TextAlign.Center


### PR DESCRIPTION
This pull request refactors the donation UI and improves code clarity in several areas. The main changes include replacing the custom `DonationButton` composable with standard `Button` components for donation options, updating icons to better match their respective payment methods, and refining comments for better readability. Additionally, minor UI text improvements and code cleanup have been made elsewhere.

**Donation UI refactor and improvements:**

* Replaced the custom `DonationButton` composable with standard `Button` components for each donation option in `DonationSheet.kt`, allowing for more flexible styling and icon usage. Each button now displays a relevant icon (e.g., `CreditCard` for Stripe, `Wallet` for PayPal) and clearer labels.
* Removed the now-unused `DonationButton` composable from `DonationSheet.kt`, simplifying the codebase.
* Added imports for new icons (`CreditCard`, `Wallet`) to support the updated donation buttons.

**Code and comment clarity improvements:**

* Updated comments in `NetworkService.kt` to use English and clarify the purpose of each code section, improving maintainability for non-French speakers. [[1]](diffhunk://#diff-9454115e04feb7dac7a60f1920d650915d041a347fbbd992de2454bcc2d89b74L31-R54) [[2]](diffhunk://#diff-9454115e04feb7dac7a60f1920d650915d041a347fbbd992de2454bcc2d89b74L87-R92)
* Simplified comments in the Play Store opening logic to be more concise in `DonationSheet.kt`.

**UI text polish:**

* Improved the French wording for blocked calls info in `HomeScreen.kt` for clarity and correctness.