### PR TITLE
Replace example configuration with actual Config object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,3 @@
 .externalNativeBuild
 .cxx
 local.properties
-
-# Configuration files with sensitive data
-app/src/main/java/com/cbouvat/android/saracroche/config/Config.kt

--- a/app/src/main/java/com/cbouvat/android/saracroche/config/Config.kt
+++ b/app/src/main/java/com/cbouvat/android/saracroche/config/Config.kt
@@ -1,0 +1,5 @@
+package com.cbouvat.android.saracroche.config
+
+object Config {
+    const val REPORT_SERVER_URL = "https://saracroche-server.cbouvat.com/report"
+}

--- a/app/src/main/java/com/cbouvat/android/saracroche/config/Config.kt.example
+++ b/app/src/main/java/com/cbouvat/android/saracroche/config/Config.kt.example
@@ -1,5 +1,0 @@
-package com.cbouvat.android.saracroche.config
-
-object Config {
-    const val REPORT_SERVER_URL = "https://your-server-url.com/report"
-}


### PR DESCRIPTION
This pull request updates the configuration for the report server URL by replacing the example configuration file with a new production-ready configuration file.

Configuration changes:

* Added a new `Config` object in `Config.kt` that sets `REPORT_SERVER_URL` to the production server endpoint.
* Removed the previous example configuration file `Config.kt.example` which contained a placeholder URL.