### PR TITLE
Remove appVersion from ReportRequest and NetworkService logic

### DIFF
--- a/app/src/main/java/com/cbouvat/android/saracroche/network/ApiModels.kt
+++ b/app/src/main/java/com/cbouvat/android/saracroche/network/ApiModels.kt
@@ -2,8 +2,7 @@ package com.cbouvat.android.saracroche.network
 
 data class ReportRequest(
     val number: String,
-    val deviceId: String,
-    val appVersion: String
+    val deviceId: String
 )
 
 data class ErrorResponse(

--- a/app/src/main/java/com/cbouvat/android/saracroche/network/NetworkService.kt
+++ b/app/src/main/java/com/cbouvat/android/saracroche/network/NetworkService.kt
@@ -1,7 +1,6 @@
 package com.cbouvat.android.saracroche.network
 
 import android.content.Context
-import android.content.pm.PackageManager
 import android.provider.Settings
 import com.cbouvat.android.saracroche.config.Config
 import com.google.gson.Gson
@@ -38,8 +37,7 @@ class NetworkService(private val context: Context) {
                 // Build request body
                 val requestData = ReportRequest(
                     number = phoneNumber,
-                    deviceId = getDeviceId(),
-                    appVersion = getAppVersion()
+                    deviceId = getDeviceId()
                 )
 
                 // Send JSON payload
@@ -105,15 +103,6 @@ class NetworkService(private val context: Context) {
             Settings.Secure.getString(context.contentResolver, Settings.Secure.ANDROID_ID)
                 ?: "unknown"
         } catch (e: Exception) {
-            "unknown"
-        }
-    }
-
-    private fun getAppVersion(): String {
-        return try {
-            val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
-            packageInfo.versionName ?: "unknown"
-        } catch (e: PackageManager.NameNotFoundException) {
             "unknown"
         }
     }


### PR DESCRIPTION
This pull request simplifies the network request payload by removing the app version information from the `ReportRequest` model and related code. The changes focus on streamlining the request data sent to the server and cleaning up unused code.

**Network request payload simplification:**

* Removed the `appVersion` field from the `ReportRequest` data class in `ApiModels.kt`, so the app version is no longer sent in report requests.
* Updated the construction of `ReportRequest` in `NetworkService.kt` to exclude the `appVersion` parameter.

**Code cleanup:**

* Deleted the `getAppVersion()` helper method and its usage from `NetworkService.kt`, since it's no longer needed.
* Removed the unnecessary import of `android.content.pm.PackageManager` from `NetworkService.kt`.