### PR TITLE
Add DataStore support for blocking anonymous calls and update dependencies

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -77,6 +77,9 @@ dependencies {
     // Gson for JSON parsing
     implementation(libs.gson)
 
+    // DataStore for preferences
+    implementation(libs.androidx.datastore.preferences)
+
     // For debugging
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)

--- a/app/src/main/java/com/cbouvat/android/saracroche/util/PreferencesManager.kt
+++ b/app/src/main/java/com/cbouvat/android/saracroche/util/PreferencesManager.kt
@@ -1,0 +1,49 @@
+package com.cbouvat.android.saracroche.util
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+
+// Extension to create DataStore instance
+private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "app_preferences")
+
+/**
+ * Manager for app preferences using DataStore
+ */
+object PreferencesManager {
+    
+    private val BLOCK_ANONYMOUS_CALLS_KEY = booleanPreferencesKey("block_anonymous_calls")
+    
+    /**
+     * Get the flow of block anonymous calls setting
+     */
+    fun getBlockAnonymousCallsFlow(context: Context): Flow<Boolean> {
+        return context.dataStore.data.map { preferences ->
+            preferences[BLOCK_ANONYMOUS_CALLS_KEY] ?: false
+        }
+    }
+    
+    /**
+     * Set the block anonymous calls setting
+     */
+    suspend fun setBlockAnonymousCalls(context: Context, blockAnonymous: Boolean) {
+        context.dataStore.edit { preferences ->
+            preferences[BLOCK_ANONYMOUS_CALLS_KEY] = blockAnonymous
+        }
+    }
+    
+    /**
+     * Get the current value of block anonymous calls setting (suspend function)
+     */
+    suspend fun getBlockAnonymousCalls(context: Context): Boolean {
+        return context.dataStore.data.map { preferences ->
+            preferences[BLOCK_ANONYMOUS_CALLS_KEY] ?: false
+        }.first()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ navigationCompose = "2.9.4"
 navigationFragmentKtx = "2.9.4"
 navigationUiKtx = "2.9.4"
 uiTextGoogleFonts = "1.9.1"
+datastore = "1.1.7"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
@@ -47,6 +48,7 @@ androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifec
 androidx-navigation-fragment-ktx = { group = "androidx.navigation", name = "navigation-fragment-ktx", version.ref = "navigationFragmentKtx" }
 androidx-navigation-ui-ktx = { group = "androidx.navigation", name = "navigation-ui-ktx", version.ref = "navigationUiKtx" }
 androidx-ui-text-google-fonts = { group = "androidx.compose.ui", name = "ui-text-google-fonts", version.ref = "uiTextGoogleFonts" }
+androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
This pull request introduces a new feature that allows users to block anonymous calls through a persistent app setting. It uses Jetpack DataStore for storing preferences, adds UI support for the new option in the settings screen, and updates the call screening logic to respect this preference. The most important changes are grouped below.

**Feature: Block Anonymous Calls**

* Added `PreferencesManager` utility (`PreferencesManager.kt`) to manage app preferences using Jetpack DataStore, including methods for getting and setting the "block anonymous calls" option.
* Updated the call screening logic in `CallScreeningService.kt` to check the "block anonymous calls" setting for incoming calls with no caller ID, blocking them if enabled.
* Enhanced the settings UI (`SettingsScreen.kt`) to display a switch for blocking anonymous calls, which is backed by DataStore and updates in real time. [[1]](diffhunk://#diff-a76118181a02d414f8d3892042b5be8553870be5d497b63cf80fc278d9a07e7dR202-R206) [[2]](diffhunk://#diff-a76118181a02d414f8d3892042b5be8553870be5d497b63cf80fc278d9a07e7dR238-R248)

**Dependencies and Configuration**

* Added DataStore Preferences library to project dependencies (`build.gradle.kts`, `libs.versions.toml`) to support persistent app settings. [[1]](diffhunk://#diff-8cff73265af19c059547b76aca8882cbaa3209291406f52df1dafbbc78e80c46R80-R82) [[2]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR21) [[3]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR51)

**Refactoring and Cleanup**

* Removed unused `SettingsSection` composable from `SettingsScreen.kt` to simplify the code.