### PR TITLE
Update SettingsScreen for call blocking clarity

### DIFF
--- a/app/src/main/java/com/cbouvat/android/saracroche/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/cbouvat/android/saracroche/ui/settings/SettingsScreen.kt
@@ -240,8 +240,8 @@ fun SettingsScreen() {
                         onClick = { openCallBlockingSettings(context) }
                     ),
                     SettingsItem.Switch(
-                        title = "Bloquer les appels anonymes",
-                        subtitle = "Bloquer automatiquement tous les appels provenant de numéros anonymes ou masqués",
+                        title = "Bloquer les appels masqués",
+                        subtitle = "Bloquer automatiquement tous les appels provenant de numéros masqués ou privés",
                         icon = Icons.Rounded.PhoneDisabled,
                         checked = blockAnonymousCallsState.value,
                         onCheckedChange = { newValue ->


### PR DESCRIPTION
This pull request makes a minor update to the wording of a settings option in the `SettingsScreen`. The change clarifies the description for blocking calls from hidden or private numbers.

* Updated the `SettingsItem.Switch` title and subtitle to "Bloquer les appels masqués" and "Bloquer automatiquement tous les appels provenant de numéros masqués ou privés" for better clarity.