### PR TITLE
Update phone number validation for French numbers

### DIFF
--- a/app/src/main/java/com/cbouvat/android/saracroche/ui/report/ReportViewModel.kt
+++ b/app/src/main/java/com/cbouvat/android/saracroche/ui/report/ReportViewModel.kt
@@ -76,9 +76,9 @@ class ReportViewModel(private val context: Context) : ViewModel() {
                 showError("Le numéro doit être au format E.164 (ex: +33612345678).")
                 return false
             }
-            // Validation for French numbers
-            trimmedNumber.startsWith("+33") && trimmedNumber.length != 12 -> {
-                showError("Les numéros français doivent contenir 12 caractères au total.")
+            // Validation for French numbers (12 or 16 digits)
+            trimmedNumber.startsWith("+33") && trimmedNumber.length != 12 && trimmedNumber.length != 16 -> {
+                showError("Les numéros français doivent contenir 12 ou 16 caractères au total.")
                 return false
             }
         }


### PR DESCRIPTION
This pull request updates the validation logic for French phone numbers in the `ReportViewModel`. The main change is to allow French numbers to have either 12 or 16 characters, improving support for alternate number formats.

Validation logic improvement:

* Updated the French phone number validation in `ReportViewModel.kt` to accept numbers with 12 or 16 characters, and changed the error message accordingly.