### PR TITLE
Remove French phone number validation for 12 or 16 digits in ReportViewModel

### DIFF
--- a/app/src/main/java/com/cbouvat/android/saracroche/ui/report/ReportViewModel.kt
+++ b/app/src/main/java/com/cbouvat/android/saracroche/ui/report/ReportViewModel.kt
@@ -76,11 +76,6 @@ class ReportViewModel(private val context: Context) : ViewModel() {
                 showError("Le numéro doit être au format E.164 (ex: +33612345678).")
                 return false
             }
-            // Validation for French numbers (12 or 16 digits)
-            trimmedNumber.startsWith("+33") && trimmedNumber.length != 12 && trimmedNumber.length != 16 -> {
-                showError("Les numéros français doivent contenir 12 ou 16 caractères au total.")
-                return false
-            }
         }
 
         return true


### PR DESCRIPTION
Eliminate the specific validation for French phone numbers that required 12 or 16 digits, simplifying the phone number validation logic.