### PR TITLE
Update help and privacy policy links to new domain

### DIFF
--- a/app/src/main/java/com/cbouvat/android/saracroche/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/cbouvat/android/saracroche/ui/settings/SettingsScreen.kt
@@ -350,7 +350,7 @@ private fun openCallBlockingSettings(context: Context) {
 // Links functions
 private fun openHelpDialog(context: Context) {
     try {
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://cbouvat.com/saracroche/help/"))
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://saracroche.org/fr/help/"))
         context.startActivity(intent)
     } catch (e: Exception) {
         // Handle error silently
@@ -360,7 +360,7 @@ private fun openHelpDialog(context: Context) {
 private fun openPrivacyPolicy(context: Context) {
     try {
         val intent =
-            Intent(Intent.ACTION_VIEW, Uri.parse("https://cbouvat.com/saracroche/privacy/"))
+            Intent(Intent.ACTION_VIEW, Uri.parse("https://saracroche.org/fr/privacy/"))
         context.startActivity(intent)
     } catch (e: Exception) {
         // Handle error silently
@@ -369,7 +369,7 @@ private fun openPrivacyPolicy(context: Context) {
 
 private fun openOfficialWebsite(context: Context) {
     try {
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://cbouvat.com/saracroche/"))
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://saracroche.org/"))
         context.startActivity(intent)
     } catch (e: Exception) {
         // Handle error silently


### PR DESCRIPTION
This pull request updates the URLs used in the settings screen to point to the new official domain for the project. The changes ensure that users are directed to the correct help page, privacy policy, and official website.

External links update:

* Updated the help dialog URL to use `https://saracroche.org/fr/help/` instead of the old domain.
* Updated the privacy policy URL to use `https://saracroche.org/fr/privacy/` instead of the old domain.
* Updated the official website URL to use `https://saracroche.org/` instead of the old domain.