### PR TITLE
Update server URL for reporting

### DIFF
--- a/app/src/main/java/com/cbouvat/android/saracroche/config/Config.kt
+++ b/app/src/main/java/com/cbouvat/android/saracroche/config/Config.kt
@@ -1,5 +1,5 @@
 package com.cbouvat.android.saracroche.config
 
 object Config {
-    const val REPORT_SERVER_URL = "https://saracroche-server.cbouvat.com/report"
+    const val REPORT_SERVER_URL = "https://saracroche.org/api/report"
 }

--- a/app/src/main/java/com/cbouvat/android/saracroche/network/ApiModels.kt
+++ b/app/src/main/java/com/cbouvat/android/saracroche/network/ApiModels.kt
@@ -1,8 +1,8 @@
 package com.cbouvat.android.saracroche.network
 
 data class ReportRequest(
-    val number: String,
-    val deviceId: String
+    val phone: Long,
+    val device_id: String
 )
 
 data class ErrorResponse(

--- a/app/src/main/java/com/cbouvat/android/saracroche/network/NetworkService.kt
+++ b/app/src/main/java/com/cbouvat/android/saracroche/network/NetworkService.kt
@@ -21,7 +21,7 @@ class NetworkService(private val context: Context) {
         private const val RESOURCE_TIMEOUT_SECONDS = 30
     }
 
-    suspend fun reportPhoneNumber(phoneNumber: String) {
+    suspend fun reportPhoneNumber(phoneNumber: Long) {
         withContext(Dispatchers.IO) {
             val url = URL(Config.REPORT_SERVER_URL)
             val connection = url.openConnection() as HttpURLConnection
@@ -30,14 +30,15 @@ class NetworkService(private val context: Context) {
                 // Connection configuration
                 connection.requestMethod = "POST"
                 connection.setRequestProperty("Content-Type", "application/json")
+                connection.setRequestProperty("Accept", "application/json")
                 connection.doOutput = true
                 connection.connectTimeout = TIMEOUT_SECONDS * 1000
                 connection.readTimeout = RESOURCE_TIMEOUT_SECONDS * 1000
 
                 // Build request body
                 val requestData = ReportRequest(
-                    number = phoneNumber,
-                    deviceId = getDeviceId()
+                    phone = phoneNumber,
+                    device_id = getDeviceId()
                 )
 
                 // Send JSON payload

--- a/app/src/main/java/com/cbouvat/android/saracroche/ui/report/ReportViewModel.kt
+++ b/app/src/main/java/com/cbouvat/android/saracroche/ui/report/ReportViewModel.kt
@@ -43,7 +43,8 @@ class ReportViewModel(private val context: Context) : ViewModel() {
             _uiState.value = _uiState.value.copy(isLoading = true)
 
             try {
-                networkService.reportPhoneNumber(_uiState.value.phoneNumber)
+                val phoneNumberAsLong = stringToLong(_uiState.value.phoneNumber)
+                networkService.reportPhoneNumber(phoneNumberAsLong)
                 handleSuccess()
             } catch (e: NetworkError) {
                 handleNetworkError(e)
@@ -116,5 +117,9 @@ class ReportViewModel(private val context: Context) : ViewModel() {
 
     private fun formatPhoneNumber(input: String): String {
         return input.replace(" ", "").filter { it.isDigit() || it == '+' }
+    }
+
+    private fun stringToLong(value: String): Long {
+        return value.replace("+", "").replace(" ", "").toLongOrNull() ?: 0L
     }
 }


### PR DESCRIPTION
This pull request updates the phone number reporting feature to improve data consistency with the backend API. The main changes include updating the API endpoint, changing the data model to use more appropriate types and field names, and ensuring the phone number is properly converted and formatted before being sent.

API integration and data model updates:

* Updated the report API endpoint URL in `Config.REPORT_SERVER_URL` to use `https://saracroche.org/api/report` instead of the old server address.
* Changed the `ReportRequest` data model: replaced `number: String` with `phone: Long` and `deviceId: String` with `device_id: String` to match backend expectations.
* Modified the `NetworkService.reportPhoneNumber` method to accept a `Long` instead of a `String` for the phone number and updated the request payload accordingly. Also, added the `Accept: application/json` header. [[1]](diffhunk://#diff-9454115e04feb7dac7a60f1920d650915d041a347fbbd992de2454bcc2d89b74L24-R24) [[2]](diffhunk://#diff-9454115e04feb7dac7a60f1920d650915d041a347fbbd992de2454bcc2d89b74R33-R41)

ViewModel and data formatting changes:

* Updated `ReportViewModel` to convert the user-inputted phone number string to a `Long` using a new `stringToLong` helper before sending it to the network service. [[1]](diffhunk://#diff-015f84d27857525918981ac65dd6812d754f04559a289ee79931201ddd5ff80bL46-R47) [[2]](diffhunk://#diff-015f84d27857525918981ac65dd6812d754f04559a289ee79931201ddd5ff80bR121-R124)